### PR TITLE
Hiding "No Matches" text upon reset button click.

### DIFF
--- a/js/jquery.liveFilter.js
+++ b/js/jquery.liveFilter.js
@@ -57,6 +57,7 @@
 
     // Used to reset our text input and show all items in the filtered list
     wrap.find('input[type="reset"]').on("click", function() {
+      nomatches.hide();
 
       if (options.defaultText === false) {
 


### PR DESCRIPTION
Currently, the "No Matches" text will remain appended to the end of a list upon clicking the reset button.  This patch hides the text before restoring the list.
